### PR TITLE
Always favor ":" when comparing buck deps

### DIFF
--- a/src/com/intellij/plugin/buck/format/DependenciesOptimizer.java
+++ b/src/com/intellij/plugin/buck/format/DependenciesOptimizer.java
@@ -84,16 +84,23 @@ public class DependenciesOptimizer {
     for (int i = 0; i < Math.min(baseString.length(), anotherString.length()); ++i) {
       char c1 = baseString.charAt(i);
       char c2 = anotherString.charAt(i);
-      if (c1 != c2) {
-        // ':' should go first when compare ':' with '/' for Buck dependencies.
-        if ((c1 == ':' && c2 == '/') || (c1 == '/' && c2 == ':')) {
-          return c2 - c1;
-        } else {
-          return c1 - c2;
-        }
+      if (c1 == c2) {
+        continue;
+      } else if (c1 == ':') {
+        return -1;
+      } else if (c2 == ':') {
+        return 1;
+      } else if (c1 == '@') {
+        return 1;
+      } else if (c2 == '@') {
+        return -1;
+      } else if (c1 < c2) {
+        return -1;
+      } else {
+        return 1;
       }
     }
-    return baseString.length() - anotherString.length();
+    return baseString.compareTo(anotherString);
   }
 
 }

--- a/testData/dependencyOptimizer/simple/after.BUCK
+++ b/testData/dependencyOptimizer/simple/after.BUCK
@@ -3,7 +3,9 @@ android_library(
   srcs = glob(['*.java']),
   deps = [
     '//libraries/code/src/main/java/com/company/common/internal:internal',
+    '//libraries/code/src/main/java/com/company/common/internal/module:module',
     '//libraries/code/src/main/java/com/company/common/util:util',
+    '//libraries/code/src/main/java/com/company/common/util-base:base',
     '//third-party/java/jsr-305:jsr-305',
   ],
   visibility = [

--- a/testData/dependencyOptimizer/simple/before.BUCK
+++ b/testData/dependencyOptimizer/simple/before.BUCK
@@ -2,8 +2,10 @@ android_library(
   name = 'common',
   srcs = glob(['*.java']),
   deps = [
+    '//libraries/code/src/main/java/com/company/common/util-base:base',
     '//third-party/java/jsr-305:jsr-305',
     '//libraries/code/src/main/java/com/company/common/util:util',
+    '//libraries/code/src/main/java/com/company/common/internal/module:module',
     '//libraries/code/src/main/java/com/company/common/internal:internal',
   ],
   visibility = [


### PR DESCRIPTION
This would would align the plugin with the logic of other BUCK utilities (e.g. linter) that expect ":" to always take precedence. Let me know what you think.
